### PR TITLE
pkgbrowser: update to 0.19

### DIFF
--- a/pkgbrowser/PKGBUILD
+++ b/pkgbrowser/PKGBUILD
@@ -1,16 +1,16 @@
 # Maintainer: kachelaqa <kachelaqa at gmail dot com>
 
 pkgname='pkgbrowser'
-pkgver=0.18
+pkgver=0.19
 pkgrel=1
 pkgdesc='A utility for browsing pacman databases and the AUR'
 arch=('i686' 'x86_64')
 url="https://bitbucket.org/kachelaqa/$pkgname"
 license=('GPL2')
-depends=('pacman>=4.1' 'pacman<4.3' 'python>=3.2' 'python-pyqt4')
+depends=('pacman>=4.1' 'pacman<4.3' 'python>=3.2' 'python-pyqt5')
 install="$pkgname.install"
 source=("$url/downloads/$pkgname-$pkgver.tar.gz")
-md5sums=('4860ee94797a5a944f97a418b5578341')
+md5sums=('4229a1206425f10bb528af5fa87b264b')
 
 build() {
     cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Change was made to AUR on: 2015-08-10 01:09.

AUR Link: [pkgbrowser 0.19-1](https://aur.archlinux.org/packages/pkgbrowser/)