### PR TITLE
Switch to pdflatex

### DIFF
--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -15,6 +15,8 @@ prepare() {
   cd ${srcdir}/manjaro-user-guide*
   lyx --export pdflatex manjaro-user-guide.lyx
   pdflatex manjaro-user-guide
+  texindy --language english manjaro-user-guide.idx
+  pdflatex manjaro-user-guide
   pdflatex manjaro-user-guide
   gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -sOutputFile=manjaro-user-guide-printer.pdf manjaro-user-guide.pdf
 }

--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -7,7 +7,7 @@ _gitcommit=89d7c05fd927064dbebc8b26150dce151db791e3
 pkgrel=1
 arch=('any')
 url="https://github.com/manjaro/manjaro-user-guide"
-makedepends=(lyx textlive-core texlive-latexextra texlive-pictures ttf-comfortaa ghostscript)
+makedepends=(lyx texlive-core texlive-latexextra texlive-pictures ttf-comfortaa ghostscript)
 source=("manjaro-documentation-$pkgver-$pkgrel.tar.gz::$url/archive/$_gitcommit.tar.gz")
 sha256sums=('41e0480821cf48c4209bf68fae648680edbdf4afb6d34bd366b7e1050e39297c')
 

--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -7,7 +7,7 @@ _gitcommit=89d7c05fd927064dbebc8b26150dce151db791e3
 pkgrel=1
 arch=('any')
 url="https://github.com/manjaro/manjaro-user-guide"
-makedepends=(lyx texlive-pictures texlive-latexextra ttf-comfortaa ghostscript)
+makedepends=(lyx textlive-core texlive-latexextra texlive-pictures ttf-comfortaa ghostscript)
 source=("manjaro-documentation-$pkgver-$pkgrel.tar.gz::$url/archive/$_gitcommit.tar.gz")
 sha256sums=('41e0480821cf48c4209bf68fae648680edbdf4afb6d34bd366b7e1050e39297c')
 

--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase=manjaro-documentation
 pkgname=('manjaro-documentation')
 pkgver=15.09
-_gitcommit=763ea5b3b73c4216b92913393f0fc0d7347896fb
+_gitcommit=89d7c05fd927064dbebc8b26150dce151db791e3
 pkgrel=1
 arch=('any')
 url="https://github.com/manjaro/manjaro-user-guide"
 makedepends=(lyx texlive-pictures texlive-latexextra ttf-comfortaa ghostscript)
 source=("manjaro-documentation-$pkgver-$pkgrel.tar.gz::$url/archive/$_gitcommit.tar.gz")
-sha256sums=('56676653340e7a1ace0591b73f5f736dfc67607b0f62ca9574d11b7687f50ab5')
+sha256sums=('41e0480821cf48c4209bf68fae648680edbdf4afb6d34bd366b7e1050e39297c')
 
 prepare() {
   cd ${srcdir}/manjaro-user-guide*

--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -13,7 +13,9 @@ sha256sums=('56676653340e7a1ace0591b73f5f736dfc67607b0f62ca9574d11b7687f50ab5')
 
 prepare() {
   cd ${srcdir}/manjaro-user-guide*
-  lyx --export pdf5 manjaro-user-guide.lyx
+  lyx --export pdflatex manjaro-user-guide.lyx
+  pdflatex manjaro-user-guide
+  pdflatex manjaro-user-guide
   gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -sOutputFile=manjaro-user-guide-printer.pdf manjaro-user-guide.pdf
 }
 


### PR DESCRIPTION
tufte-book has issues with XeTeX and LuaLaTeX with TeX Live 2015, so let's just use pdflatex instead. Yes, it does need to be run twice in succession to fully process the file properly.