### PR TITLE
Fix /etc/brlapi.key permissions

### DIFF
--- a/brltty/PKGBUILD
+++ b/brltty/PKGBUILD
@@ -1,0 +1,42 @@
+# $Id$
+# Maintainer: Tom Gundersen <teg@jklm.no>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Giovanni Scafora <giovanni@archlinux.org>
+
+pkgname=brltty
+pkgver=5.2
+pkgrel=6
+pkgdesc="Braille display driver for Linux/Unix"
+arch=(i686 x86_64)
+url="http://mielke.cc/brltty"
+license=(GPL LGPL)
+depends=(libxaw gpm icu tcl cython bluez-libs)
+makedepends=(at-spi2-core tcl)
+optdepends=('at-spi2-core: X11/GNOME Apps accessibility'
+            'atk: ATK bridge for X11/GNOME accessibility')
+backup=(etc/brltty.conf)
+options=('!emptydirs')
+install=brltty.install
+source=(http://mielke.cc/brltty/archive/brltty-$pkgver.tar.xz
+        brltty.service)
+md5sums=('b484343461b5a45f95fedfb21d1ceca3'
+         '0cad54bb5470122535f5e3a11d5ca123')
+
+build() {
+  cd $pkgname-$pkgver
+  ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+    --mandir=/usr/share/man \
+    --with-tables-directory=/usr/share/brltty \
+    --with-screen-driver=lx \
+    --enable-gpm \
+    --disable-java-bindings
+
+  make
+}
+
+package() {
+  cd $pkgname-$pkgver
+  make INSTALL_ROOT="$pkgdir" install
+  install -Dm644 Documents/brltty.conf "$pkgdir/etc/brltty.conf"
+  install -Dm644 ../brltty.service "$pkgdir/usr/lib/systemd/system/brltty.service"
+}

--- a/brltty/brltty.install
+++ b/brltty/brltty.install
@@ -1,0 +1,16 @@
+post_install () {
+     if [ ! -e /etc/brlapi.key ]; then
+         mcookie >/etc/brlapi.key
+         chmod 0644 /etc/brlapi.key
+     fi
+}
+
+post_upgrade () {
+    post_install
+}
+
+post_remove () {
+    if [ -e /etc/brlapi.key ]; then
+        rm -f /etc/brlapi.key
+    fi
+}

--- a/brltty/brltty.service
+++ b/brltty/brltty.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Braille Console Driver
+DefaultDependencies=no
+Before=sysinit.target
+
+[Service]
+ExecStart=/usr/bin/brltty --pid-file=/run/brltty.pid
+Type=forking
+PIDFile=/run/brltty.pid
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
The original ARCH package with install operation created the brlapi group, and the /etc/brlapi.key file owner is root user and brlapi group.
If an Orca user username not part of the brlapi group, Orca unable to communicate the BRLTTY daemon.
This fix I deleted the brlapi group related parts in the brltty.install file and change /etc/brlapi.key file permissions with 0644 permission.
This change resulting to all Orca users have possibility to use Orca braille support with BRLTTY daemon if BRLTTY autostarted with systemd or started manual.
This fix important with Sonar distribution users, please review this fix.
I tested this fix with my KVM virtual machine a real USB Alva Satellite 570 braille display.