### PR TITLE
Remove menda-square-icon-theme optional dependency

### DIFF
--- a/menda-themes/PKGBUILD
+++ b/menda-themes/PKGBUILD
@@ -11,7 +11,6 @@ url="https://github.com/manjaro/artwork-menda"
 license=('GPL3')
 depends=('gtk-engine-murrine' 'gtk-engines')
 optdepends=('menda-circle-icon-theme: Recommended icon theme'
-            'menda-square-icon-theme: Recommended icon theme'
             'faenza-green-icon-theme: Recommended icon theme')
 source=("${pkgbase}-${pkgver}-${pkgrel}.tar.gz::${url}/archive/${_git}.tar.gz")
 sha1sums=('SKIP')


### PR DESCRIPTION
menda-square-icon-theme was removed a time ago.

I am not sure is the right place to make this change. In PKGBUILD is `pkgver=20150413` and I have installed `20151217`.