### PR TITLE
change URL source for aic94xx firmware, add LICENSE.aic94xx

### DIFF
--- a/manjaro-firmware/LICENSE.aic94xx
+++ b/manjaro-firmware/LICENSE.aic94xx
@@ -1,0 +1,56 @@
+ADAPTEC, INC. DOWNLOADABLE SOFTWARE LICENSE 
+
+Directions to Obtain Your File: Please read the downloadable software license and answer the required question below. 
+Eligible users will then have access to the requested file. Adaptec reserves the right to record all activities.
+
+THE ADAPTEC SOFTWARE ("SOFTWARE") IS LICENSED TO YOU FOR USE IN ACCORDANCE WITH THIS ADAPTEC SOFTWARE LICENSE. IF YOU ARE NOT WILLING TO ABIDE BY THESE TERMS AND CONDITIONS, DO 
+NOT USE THE SOFTWARE. BY USING THE SOFTWARE, YOU ARE GIVING YOUR ASSENT TO THE TERMS OF THIS LICENSE.
+
+1. LICENSE. Adaptec grants to you a non-exclusive, non-transferable, worldwide license to copy the Software in object code form only, combine it with your software and 
+distribute it, directly to customers, or through your distribution network. You shall have no right to grant any license or sublicense to any third party, to use the Software 
+for any purpose, except a sublicense to use and distribute the copy produced and distributed by you. You shall have no right to modify all or any part of the Software. You shall 
+not disassemble, decompile or otherwise reverse engineer the Software nor permit any third party to do so. All rights not expressly granted herein are reserved by Adaptec.
+
+2. PROPRIETARY OWNERSHIP RIGHTS. Adaptec shall retain all ownership, right, title and interest in and to all current and hereafter existing revisions of or modifications to the 
+Software, including all copies made hereunder and all intellectual property rights related thereto. All copies of the Software made by you shall contain Adaptec's copyright 
+notice and you shall not remove any copyright notices contained in the Software.
+
+3. WARRANTY EXCLUSION. THE SOFTWARE IS PROVIDED "AS IS". ADAPTEC MAKES NO WARRANTY OF ANY KIND WITH REGARD TO THE SOFTWARE. ADAPTEC EXPRESSLY DISCLAIMS ANY OTHER WARRANTIES, 
+EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, WHETHER ARISING IN LAW, CUSTOM, CONDUCT OR OTHERWISE.
+
+4. LIMITATION OF LIABILITY. IN NO EVENT SHALL EITHER PARTY BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF USE, CONSEQUENTIAL, SPECIAL OR INCIDENTAL DAMAGES ARISING UNDER THIS 
+AGREEMENT, EVEN IF THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL ANY DAMAGES ATTRIBUTABLE TO ADAPTEC EXCEED THE AMOUNT OF PAYMENTS MADE 
+TO ADAPTEC UNDER THIS AGREEMENT.
+
+5. TERMINATION OF THIS AGREEMENT. Adaptec may terminate this Agreement if you violate its terms. Upon termination, you will immediately destroy the Software or return all copies 
+of the Software to Adaptec.
+
+6. APPLICABLE LAW. This Agreement shall be governed by the laws of the State of California, USA, excluding its principles of conflict of laws and the United Nations Convention 
+on Contracts for the Sale of Goods.
+
+7. AMENDMENT, SEVERABILITY, WAIVER. No supplement or amendment of this Agreement shall be binding, unless executed in writing by both parties and specifically referencing the 
+supplementing or amendment of this Agreement. Any provision of this Agreement found to be illegal or unenforceable shall be deemed severed, and the balance of this Agreement 
+shall remain in full force and effect. Neither party's right to require performance of the other party's obligations hereunder shall be affected by any previous waiver, 
+forbearance or course of dealing, unless or only to the extent of any waiver given in writing. Failure or delay by either party to exercise any of its rights, powers or remedies 
+hereunder shall not constitute a waiver of those rights, powers or remedies.
+
+8. EXPORT COMPLIANCE. Each party agrees that the Software is subject to the U.S. Export Administration Act and Export Administration Regulations, as well as applicable import 
+and export regulations of the countries in which each party transacts business. Each party shall comply with such laws and regulations, as well as all other laws and regulations 
+applicable to the Software. Each party agrees that it will not export, re-export, transfer or divert any of the Software to any country for which United States' laws or 
+regulations require an export license or other governmental approval, without first obtaining such license or approval, nor will each party export, re-export, transfer or divert 
+any of the Software to any restricted place or party in accordance with U.S. export regulations.
+
+9. GOVERNMENT RESTRICTED RIGHTS. The Software is provided with RESTRICTED RIGHTS. Use, duplication or disclosure by the Government is subject to restrictions as set forth in 
+FAR52.227-14 and DFAR252.227-7013 et. seq. or their successors. Us of the Software by the Government constitutes acknowledgment of Adaptec's proprietary right therein. Adaptec, 
+Inc., 691 South Milpitas Boulevard, Milpitas, California 95035
+
+    * Bureau of Industry and Security's Lists to Check
+
+If you have any questions concerning this License, contact:
+
+Adaptec, Inc.
+Legal Department
+691 South Milpitas Boulevard
+Milpitas, California 95035.
+t.(408) 957-1718
+f.(408) 957-7137

--- a/manjaro-firmware/PKGBUILD
+++ b/manjaro-firmware/PKGBUILD
@@ -6,12 +6,12 @@
 _b43=5.100.138
 _legacy=3.130.20.0
 _nouveau=325.15
-_aic94xx=30-6.el7
+_aic94xx=30-1
 _aic94xxver=7.1.1503
 
 pkgname=('manjaro-firmware')
 pkgver=20$(date +%y%m%d)
-pkgrel=2
+pkgrel=1
 arch=('any')
 url="http://manjaro.org"
 license=('GPL' 'MPL' 'custom')
@@ -23,14 +23,15 @@ noextract=('pciscsi.exe')
 source=("broadcom-wl-${_b43}.tar.bz2::http://www.lwfinger.com/b43-firmware/broadcom-wl-${_b43}.tar.bz2"
         "wl_apsta-${_legacy}.o::http://downloads.openwrt.org/sources/wl_apsta-${_legacy}.o"
         "pciscsi.exe::http://support.wdc.com/download/archive/pciscsi.exe"
-        "aic94xx-firmware-${_aic94xx}.noarch.rpm::ftp://ftp.pbone.net/mirror/ftp.centos.org/${_aic94xxver}/os/x86_64/Packages/aic94xx-firmware-${_aic94xx}.noarch.rpm"
+        "aic94xx-seq-${_aic94xx}.tar.gz::http://download.adaptec.com/scsi/linux/aic94xx-seq-${_aic94xx}.tar.gz" "LICENSE.aic94xx"
         "extract_firmware.py::https://raw.github.com/imirkin/re-vp2/master/extract_firmware.py"
         "NVIDIA-Linux-x86-${_nouveau}.run::http://us.download.nvidia.com/XFree86/Linux-x86/${_nouveau}/NVIDIA-Linux-x86-${_nouveau}.run")
         
 sha256sums=('f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f'
             '7dba610b1d96dd14e901bcbce14cd6ecd1b1ac6f5c0035b0d6b6dc46a7c3ef90'
             'd310338eaaeae6db3673021c0ec2ec23b9cfb9f9b9d1eb8854d2d60b3a6490f9'
-            '1db12b5979cf561cb030c9d695969e5c4d76e55c0e1f8dd4795b86eddb3d3669'
+            '0608a919b95e65e8fe3c0cbc15f7e559716bda39a6efca863417a65f75e15478'
+            '6e0dd2831a66437e87659ed31384f11bdc7720bc539d2efa063fbb7f4ac0e46c'
             '154bbf69e593b407448fcdb4c7804464a827dd9c6cde1048ec484b06680cad0d'
             '3d790e4bfed24641f7cc76879144ab5d52b12271012ba381b0d33aa1a2e08775')
             
@@ -46,8 +47,8 @@ build() {
     dd if=wd7296a.sys of=wd719x-wcs.bin bs=1 skip=20096 count=514
     
     # extract aic94xx firmware
-    bsdtar xvf "aic94xx-firmware-${_aic94xx}.noarch.rpm"
-    
+    bsdtar xvf "aic94xx_seq-${_aic94xx}.noarch.rpm"
+    chmod 644  "${srcdir}/lib/firmware/aic94xx-seq.fw"
 }
 
 package() {
@@ -64,9 +65,9 @@ package() {
     cp -a nv* vuc-* "${pkgdir}"/usr/lib/firmware/nouveau/
   
     # install aic94xx firmware
-    install -D -m644 ${srcdir}/lib/firmware/aic94xx-seq.fw                       ${pkgdir}/usr/lib/firmware/aic94xx-seq.fw
-    install -D -m644 ${srcdir}/usr/share/doc/aic94xx-firmware-30/LICENSE.aic94xx ${pkgdir}/usr/share/doc/${pkgname}/LICENSE.aic94xx
-    install -D -m644 ${srcdir}/usr/share/doc/aic94xx-firmware-30/README-94xx.pdf ${pkgdir}/usr/share/doc/${pkgname}/README-94xx.pdf
+    install -Dm644 ${srcdir}/lib/firmware/aic94xx-seq.fw ${pkgdir}/usr/lib/firmware/aic94xx-seq.fw
+    install -Dm644 ${srcdir}/LICENSE.aic94xx             ${pkgdir}/usr/share/doc/${pkgname}/LICENSE.aic94xx
+    install -Dm644 ${srcdir}/README-94xx.pdf             ${pkgdir}/usr/share/doc/${pkgname}/README-94xx.pdf
     
     # install wd719x firmware
     install -D -m644 ${srcdir}/wd719x-risc.bin ${pkgdir}/usr/lib/firmware/wd719x-risc.bin


### PR DESCRIPTION
I found direct link for aic94xx. Currently used in manjaro-firmware package URL for RPM is dead.
Package build localy - all is fine.

@philmmanjaro