### PR TITLE
Firmware  for BCM20702A1 and QCA9565 BT devices

### DIFF
--- a/manjaro-firmware/PKGBUILD
+++ b/manjaro-firmware/PKGBUILD
@@ -8,6 +8,8 @@ _legacy=3.130.20.0
 _nouveau=340.32
 _aic94xx=30-1
 _aic94xxver=7.1.1503
+_bcm20702a1=1201650
+_qca9565name=linux-firmware_1.144+ar3012~vivid
 
 pkgname=('manjaro-firmware')
 pkgver=20$(date +%y%m%d)
@@ -15,17 +17,19 @@ pkgrel=1
 arch=('any')
 url="http://manjaro.org"
 license=('GPL' 'MPL' 'custom')
-makedepends=('b43-fwcutter' 'lha' 'python2')
+makedepends=('b43-fwcutter' 'bluez-utils' 'lha' 'python2')
 pkgdesc="Extra firmwares for Manjaro Linux"
-provides=('nouveau-fw' 'b43-firmware-classic' 'b43-firmware-legacy' 'wd719x-firmware' 'aic94xx-firmware')
-conflicts=('nouveau-fw' 'b43-firmware-classic' 'b43-firmware' 'b43-firmware-legacy' 'wd719x-firmware' 'aic94xx-firmware')
+provides=('nouveau-fw' 'b43-firmware-classic' 'b43-firmware-legacy' 'wd719x-firmware' 'aic94xx-firmware' 'bcm20702a1-firmware' 'qca9565-bluetooth-firmware')
+conflicts=('nouveau-fw' 'b43-firmware-classic' 'b43-firmware' 'b43-firmware-legacy' 'wd719x-firmware' 'aic94xx-firmware' 'bcm20702a1-firmware' 'qca9565-bluetooth-firmware')
 noextract=('pciscsi.exe')
 source=("broadcom-wl-${_b43}.tar.bz2::http://www.lwfinger.com/b43-firmware/broadcom-wl-${_b43}.tar.bz2"
         "wl_apsta-${_legacy}.o::http://downloads.openwrt.org/sources/wl_apsta-${_legacy}.o"
         "pciscsi.exe::http://support.wdc.com/download/archive/pciscsi.exe"
         "aic94xx-seq-${_aic94xx}.tar.gz::http://download.adaptec.com/scsi/linux/aic94xx-seq-${_aic94xx}.tar.gz" "LICENSE.aic94xx"
         "extract_firmware.py::https://raw.github.com/imirkin/re-vp2/master/extract_firmware.py"
-        "NVIDIA-Linux-x86-${_nouveau}.run::http://us.download.nvidia.com/XFree86/Linux-x86/${_nouveau}/NVIDIA-Linux-x86-${_nouveau}.run")
+        "NVIDIA-Linux-x86-${_nouveau}.run::http://us.download.nvidia.com/XFree86/Linux-x86/${_nouveau}/NVIDIA-Linux-x86-${_nouveau}.run"
+        "Bluetooth_V${_bcm20702a1}_WHQL_Win10.zip::http://dlcdnet.asus.com/pub/ASUS/misc/BT/Bluetooth_V${_bcm20702a1}_WHQL_Win10.zip"
+        "${_qca9565name}.tar.gz::https://launchpad.net/~hanipouspilot/+archive/ubuntu/rtlwifi/+files/${_qca9565name}.tar.gz")
         
 sha256sums=('f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f'
             '7dba610b1d96dd14e901bcbce14cd6ecd1b1ac6f5c0035b0d6b6dc46a7c3ef90'
@@ -33,7 +37,9 @@ sha256sums=('f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f'
             '0608a919b95e65e8fe3c0cbc15f7e559716bda39a6efca863417a65f75e15478'
             '6e0dd2831a66437e87659ed31384f11bdc7720bc539d2efa063fbb7f4ac0e46c'
             '154bbf69e593b407448fcdb4c7804464a827dd9c6cde1048ec484b06680cad0d'
-            '1d0489c35c5b332c9b949d9de3c3cbab4ac3a94385aa41e7a7b62ef23f4395f5')
+            '1d0489c35c5b332c9b949d9de3c3cbab4ac3a94385aa41e7a7b62ef23f4395f5'
+            'b8863fdb2f397c1ca7264fd4a0f457c2f9ab90350338e476128fb241720e32ad'
+            'a57ffa0ff6d80f10ebaa3878a736b2adcfccd76fb4787477d4096087e2826961')
             
 build() {
     #extract nouveau firmware
@@ -49,6 +55,11 @@ build() {
     # extract aic94xx firmware
     bsdtar xvf "aic94xx_seq-${_aic94xx}.noarch.rpm"
     chmod 644  "${srcdir}/lib/firmware/aic94xx-seq.fw"
+    
+    # extract bcm20702a1 firmware
+    hex2hcd "$srcdir/Bluetooth/BCM_DriverOnly/64/BCM20702A1_001.002.014.1443.1467.hex" -o "${srcdir}/BCM20702A1-0b05-17cb.hcd"
+    hex2hcd "$srcdir/Bluetooth/BCM_DriverOnly/64/BCM20702A1_001.002.014.1443.1469.hex" -o "${srcdir}/BCM20702A1-0b05-17cf.hcd"
+    
 }
 
 package() {
@@ -65,12 +76,23 @@ package() {
     cp -a nv* vuc-* "${pkgdir}"/usr/lib/firmware/nouveau/
   
     # install aic94xx firmware
+    # firmware for Adaptec aic94xx SAS/SATA chipset based devices
     install -Dm644 ${srcdir}/lib/firmware/aic94xx-seq.fw ${pkgdir}/usr/lib/firmware/aic94xx-seq.fw
     install -Dm644 ${srcdir}/LICENSE.aic94xx             ${pkgdir}/usr/share/doc/${pkgname}/LICENSE.aic94xx
     install -Dm644 ${srcdir}/README-94xx.pdf             ${pkgdir}/usr/share/doc/${pkgname}/README-94xx.pdf
     
     # install wd719x firmware
-    install -D -m644 ${srcdir}/wd719x-risc.bin ${pkgdir}/usr/lib/firmware/wd719x-risc.bin
-    install -D -m644 ${srcdir}/wd719x-wcs.bin  ${pkgdir}/usr/lib/firmware/wd719x-wcs.bin
+    # firmware for Western Digital WD7193/7197/7296 SCSI chipset based devices
+    install -Dm644 ${srcdir}/wd719x-risc.bin ${pkgdir}/usr/lib/firmware/wd719x-risc.bin
+    install -Dm644 ${srcdir}/wd719x-wcs.bin  ${pkgdir}/usr/lib/firmware/wd719x-wcs.bin
+    
+    # install bcm20702a1 bluetooth firmware
+    # firmware for BCM20702A1 bluetooth chipset based devices
+    install -Dm644 ${srcdir}/BCM20702A1-0b05-17cb.hcd ${pkgdir}/usr/lib/firmware/brcm/BCM20702A1-0b05-17cb.hcd
+    install -Dm644 ${srcdir}/BCM20702A1-0b05-17cf.hcd ${pkgdir}/usr/lib/firmware/brcm/BCM20702A1-0b05-17cf.hcd
+    
+    # install qca9565 bluetooth firmware
+    # firmware for Qualcomm Atheros QCA9565 bluetooth chipset based devices
+    install -Dm644 ${srcdir}/${_qca9565name/_/-}/ar3k/AthrBT_0x31010100.dfu     ${pkgdir}/usr/lib/firmware/ar3k/AthrBT_0x31010100.dfu
+    install -Dm644 ${srcdir}/${_qca9565name/_/-}/ar3k/ramps_0x31010100_40.dfu   ${pkgdir}/usr/lib/firmware/ar3k/ramps_0x31010100_40.dfu
 }
-


### PR DESCRIPTION
Adding firmware for:
- Qualcomm Atheros QCA9565 bluetooth chipset based devices
- BCM20702A1 bluetooth chipset based devices

Expand comments. 
Tested localy, all is fine.

@philmmanjaro
