### PR TITLE
intel-ucode 20151106

### DIFF
--- a/intel-ucode/LICENSE
+++ b/intel-ucode/LICENSE
@@ -1,0 +1,123 @@
+INTEL SOFTWARE LICENSE AGREEMENT
+
+IMPORTANT - READ BEFORE COPYING, INSTALLING OR USING.
+Do not use or load this software and any associated materials (collectively,
+the "Software") until you have carefully read the following terms and
+conditions. By loading or using the Software, you agree to the terms of this
+Agreement. If you do not wish to so agree, do not install or use the Software.
+
+LICENSES: Please Note:
+- If you are a network administrator, the "Site License" below shall
+apply to you.
+- If you are an end user, the "Single User License" shall apply to you.
+- If you are an original equipment manufacturer (OEM), the "OEM License"
+shall apply to you.
+
+SITE LICENSE. You may copy the Software onto your organization's computers
+for your organization's use, and you may make a reasonable number of
+back-up copies of the Software, subject to these conditions:
+
+1. This Software is licensed for use only in conjunction with Intel
+component products. Use of the Software in conjunction with non-Intel
+component products is not licensed hereunder.
+2. You may not copy, modify, rent, sell, distribute or transfer any part
+of the Software except as provided in this Agreement, and you agree to
+prevent unauthorized copying of the Software.
+3. You may not reverse engineer, decompile, or disassemble the Software.
+4. You may not sublicense or permit simultaneous use of the Software by
+more than one user.
+5. The Software may include portions offered on terms in addition to those
+set out here, as set out in a license accompanying those portions.
+
+SINGLE USER LICENSE. You may copy the Software onto a single computer for
+your personal, noncommercial use, and you may make one back-up copy of the
+Software, subject to these conditions:
+
+1. This Software is licensed for use only in conjunction with Intel
+component products. Use of the Software in conjunction with non-Intel
+component products is not licensed hereunder.
+2. You may not copy, modify, rent, sell, distribute or transfer any part
+of the Software except as provided in this Agreement, and you agree to
+prevent unauthorized copying of the Software.
+3. You may not reverse engineer, decompile, or disassemble the Software.
+4. You may not sublicense or permit simultaneous use of the Software by
+more than one user.
+5. The Software may include portions offered on terms in addition to those
+set out here, as set out in a license accompanying those portions.
+
+OEM LICENSE: You may reproduce and distribute the Software only as an
+integral part of or incorporated in Your product or as a standalone
+Software maintenance update for existing end users of Your products,
+excluding any other standalone products, subject to these conditions:
+
+1. This Software is licensed for use only in conjunction with Intel
+component products. Use of the Software in conjunction with non-Intel
+component products is not licensed hereunder.
+2. You may not copy, modify, rent, sell, distribute or transfer any part
+of the Software except as provided in this Agreement, and you agree to
+prevent unauthorized copying of the Software.
+3. You may not reverse engineer, decompile, or disassemble the Software.
+4. You may only distribute the Software to your customers pursuant to a
+written license agreement. Such license agreement may be a "break-the-
+seal" license agreement. At a minimum such license shall safeguard
+Intel's ownership rights to the Software.
+5. The Software may include portions offered on terms in addition to those
+set out here, as set out in a license accompanying those portions.
+
+NO OTHER RIGHTS. No rights or licenses are granted by Intel to You, expressly
+or by implication, with respect to any proprietary information or patent,
+copyright, mask work, trademark, trade secret, or other intellectual property
+right owned or controlled by Intel, except as expressly provided in this
+Agreement.
+
+OWNERSHIP OF SOFTWARE AND COPYRIGHTS. Title to all copies of the Software
+remains with Intel or its suppliers. The Software is copyrighted and
+protected by the laws of the United States and other countries, and
+international treaty provisions. You may not remove any copyright notices
+from the Software. Intel may make changes to the Software, or to items
+referenced therein, at any time without notice, but is not obligated to
+support or update the Software. Except as otherwise expressly provided, Intel
+grants no express or implied right under Intel patents, copyrights,
+trademarks, or other intellectual property rights. You may transfer the
+Software only if the recipient agrees to be fully bound by these terms and if
+you retain no copies of the Software.
+
+LIMITED MEDIA WARRANTY. If the Software has been delivered by Intel on
+physical media, Intel warrants the media to be free from material physical
+defects for a period of ninety days after delivery by Intel. If such a defect
+is found, return the media to Intel for replacement or alternate delivery of
+the Software as Intel may select.
+
+EXCLUSION OF OTHER WARRANTIES. EXCEPT AS PROVIDED ABOVE, THE SOFTWARE IS
+PROVIDED "AS IS" WITHOUT ANY EXPRESS OR IMPLIED WARRANTY OF ANY KIND
+INCLUDING WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT, OR FITNESS FOR A
+PARTICULAR PURPOSE. Intel does not warrant or assume responsibility for the
+accuracy or completeness of any information, text, graphics, links or other
+items contained within the Software.
+
+LIMITATION OF LIABILITY. IN NO EVENT SHALL INTEL OR ITS SUPPLIERS BE LIABLE
+FOR ANY DAMAGES WHATSOEVER (INCLUDING, WITHOUT LIMITATION, LOST PROFITS,
+BUSINESS INTERRUPTION, OR LOST INFORMATION) ARISING OUT OF THE USE OF OR
+INABILITY TO USE THE SOFTWARE, EVEN IF INTEL HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES. SOME JURISDICTIONS PROHIBIT EXCLUSION OR
+LIMITATION OF LIABILITY FOR IMPLIED WARRANTIES OR CONSEQUENTIAL OR INCIDENTAL
+DAMAGES, SO THE ABOVE LIMITATION MAY NOT APPLY TO YOU. YOU MAY ALSO HAVE
+OTHER LEGAL RIGHTS THAT VARY FROM JURISDICTION TO JURISDICTION.
+
+TERMINATION OF THIS AGREEMENT. Intel may terminate this Agreement at any time
+if you violate its terms. Upon termination, you will immediately destroy the
+Software or return all copies of the Software to Intel.
+
+APPLICABLE LAWS. Claims arising under this Agreement shall be governed by the
+laws of California, excluding its principles of conflict of laws and the
+United Nations Convention on Contracts for the Sale of Goods. You may not
+export the Software in violation of applicable export laws and regulations.
+Intel is not obligated under any other agreements unless they are in writing
+and signed by an authorized representative of Intel.
+
+GOVERNMENT RESTRICTED RIGHTS. The Software is provided with "RESTRICTED
+RIGHTS." Use, duplication, or disclosure by the Government is subject to
+restrictions as set forth in FAR52.227-14 and DFAR252.227-7013 et seq. or its
+successor. Use of the Software by the Government constitutes acknowledgment
+of Intel's proprietary rights therein. Contractor or Manufacturer is Intel
+2200 Mission College Blvd., Santa Clara, CA 95052. 

--- a/intel-ucode/PKGBUILD
+++ b/intel-ucode/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=intel-ucode
 pkgver=20151106
-pkgrel=1
+pkgrel=0.1
 pkgdesc="Microcode update files for Intel CPUs"
 arch=('any')
 install=$pkgname.install

--- a/intel-ucode/PKGBUILD
+++ b/intel-ucode/PKGBUILD
@@ -1,0 +1,37 @@
+# $Id: PKGBUILD 233080 2015-03-08 11:34:44Z tpowa $
+# Maintainer: Thomas Bächler <thomas@archlinux.org>
+
+pkgname=intel-ucode
+pkgver=20151106
+pkgrel=1
+pkgdesc="Microcode update files for Intel CPUs"
+arch=('any')
+install=$pkgname.install
+url="http://downloadcenter.intel.com/SearchResult.aspx?lang=eng&keyword=%22microcode%22"
+replaces=('microcode_ctl')
+license=('custom')
+# Some random "download id" that intel has in their downloadcenter
+_dlid=25512
+source=(http://downloadmirror.intel.com/${_dlid}/eng/microcode-${pkgver}.tgz
+        LICENSE
+        intel-microcode2ucode.c)
+sha256sums=('096e39489eef67666be652e81fa372a06b74f39ea3d565dc0287242c668717e7'
+            '6983e83ec10c6467fb9101ea496e0443f0574c805907155118e2c9f0bbea97b6'
+            '03a13a966316a4d3d9c7e1b46007fd4b80911aea5ddd957ddf33ce660efe03de')
+build() {
+  cd "$srcdir"
+  gcc -Wall ${CFLAGS} -o intel-microcode2ucode intel-microcode2ucode.c
+  ./intel-microcode2ucode ./microcode.dat
+}
+
+package() {
+  cd "$srcdir"
+
+  install -d -m755 "${pkgdir}"/boot
+
+  mkdir -p kernel/x86/microcode
+  mv microcode.bin kernel/x86/microcode/GenuineIntel.bin
+  echo kernel/x86/microcode/GenuineIntel.bin | bsdcpio -o -H newc -R 0:0 > "${pkgdir}"/boot/intel-ucode.img
+  
+  install -D -m644 LICENSE "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
+}

--- a/intel-ucode/intel-microcode2ucode.c
+++ b/intel-ucode/intel-microcode2ucode.c
@@ -1,0 +1,154 @@
+/*
+ * Convert Intel microcode.dat into a single binary microcode.bin file
+ *
+ * Based on code by Kay Sievers <kay.sievers@vrfy.org>
+ * Changed to create a single file by Thomas Bächler <thomas@archlinux.org>
+ */
+
+
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+struct microcode_header_intel {
+	unsigned int hdrver;
+	unsigned int rev;
+	unsigned int date;
+	unsigned int sig;
+	unsigned int cksum;
+	unsigned int ldrver;
+	unsigned int pf;
+	unsigned int datasize;
+	unsigned int totalsize;
+	unsigned int reserved[3];
+};
+
+union mcbuf {
+	struct microcode_header_intel hdr;
+	unsigned int i[0];
+	char c[0];
+};
+
+int main(int argc, char *argv[])
+{
+	const char *filename = "/lib/firmware/microcode.dat";
+	FILE *f;
+	char line[LINE_MAX];
+	char buf[4000000];
+	union mcbuf *mc;
+	size_t bufsize, count, start;
+	int rc = EXIT_SUCCESS;
+
+	if (argv[1] != NULL)
+		filename = argv[1];
+
+	count = 0;
+	mc = (union mcbuf *) buf;
+	f = fopen(filename, "re");
+	if (f == NULL) {
+		printf("open %s: %m\n", filename);
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	while (fgets(line, sizeof(line), f) != NULL) {
+		if (sscanf(line, "%x, %x, %x, %x",
+		    &mc->i[count],
+		    &mc->i[count + 1],
+		    &mc->i[count + 2],
+		    &mc->i[count + 3]) != 4)
+			continue;
+		count += 4;
+	}
+	fclose(f);
+
+	bufsize = count * sizeof(int);
+	printf("%s: %lu(%luk) bytes, %zu integers\n",
+	       filename,
+	       bufsize,
+	       bufsize / 1024,
+	       count);
+
+	if (bufsize < sizeof(struct microcode_header_intel))
+		goto out;
+
+	f = fopen("microcode.bin", "we");
+	if (f == NULL) {
+		printf("open microcode.bin: %m\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	start = 0;
+	for (;;) {
+		size_t size;
+		unsigned int family, model, stepping;
+		unsigned int year, month, day;
+
+		mc = (union mcbuf *) &buf[start];
+
+		if (mc->hdr.totalsize)
+			size = mc->hdr.totalsize;
+		else
+			size = 2000 + sizeof(struct microcode_header_intel);
+
+		if (mc->hdr.ldrver != 1 || mc->hdr.hdrver != 1) {
+			printf("unknown version/format:\n");
+			rc = EXIT_FAILURE;
+			break;
+		}
+
+		/*
+		 *  0- 3 stepping
+		 *  4- 7 model
+		 *  8-11 family
+		 * 12-13 type
+		 * 16-19 extended model
+		 * 20-27 extended family
+		 */
+		family = (mc->hdr.sig >> 8) & 0xf;
+		if (family == 0xf)
+			family += (mc->hdr.sig >> 20) & 0xff;
+		model = (mc->hdr.sig >> 4) & 0x0f;
+		if (family == 0x06)
+			model += ((mc->hdr.sig >> 16) & 0x0f) << 4;
+		stepping = mc->hdr.sig & 0x0f;
+
+		year = mc->hdr.date & 0xffff;
+		month = mc->hdr.date >> 24;
+		day = (mc->hdr.date >> 16) & 0xff;
+
+		printf("\n");
+		printf("signature: 0x%02x\n", mc->hdr.sig);
+		printf("flags:     0x%02x\n", mc->hdr.pf);
+		printf("revision:  0x%02x\n", mc->hdr.rev);
+		printf("date:      %04x-%02x-%02x\n", year, month, day);
+		printf("size:      %zu\n", size);
+
+		if (fwrite(mc, size, 1, f) != 1) {
+			printf("write microcode.bin: %m\n");
+			rc = EXIT_FAILURE;
+			goto out;
+		}
+
+		start += size;
+		if (start >= bufsize)
+			break;
+	}
+	fclose(f);
+	printf("\n");
+out:
+	return rc;
+}

--- a/intel-ucode/intel-ucode.install
+++ b/intel-ucode/intel-ucode.install
@@ -1,0 +1,12 @@
+## arg 1:  the new package version
+## arg 2:  the old package version
+post_upgrade() {
+  if [ $(vercmp $2 20140913) -lt 0 ]; then
+    echo "Intel CPU ucode upgrades are no longer performed by the firmware loader."
+    echo "If you want to update the Intel CPU ucode on boot, add the file"
+    echo " /boot/intel-ucode.img"
+    echo "as the first initrd to your bootloader."
+    echo
+    echo "For more information, see https://wiki.archlinux.org/index.php/Microcode#Enabling_Intel_Microcode_Updates"
+  fi
+}


### PR DESCRIPTION
Intel released new microcode in 2015-11-06. Arch using [out-of-date intel cpu's microcode package](https://www.archlinux.org/packages/extra/any/intel-ucode/).

Update working as expected.

@philmmanjaro 