### PR TITLE
bbswitch: [PATCH] Disable DSM if power resources are in use

### DIFF
--- a/linux310-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux310-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux310-extramodules/bbswitch/PKGBUILD
+++ b/linux310-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.10-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=23
+pkgrel=24
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux310-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux310-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux312-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux312-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux312-extramodules/bbswitch/PKGBUILD
+++ b/linux312-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.12-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=26
+pkgrel=27
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux312-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux312-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux314-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux314-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux314-extramodules/bbswitch/PKGBUILD
+++ b/linux314-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.14-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=26
+pkgrel=27
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux314-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux314-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux316-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux316-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux316-extramodules/bbswitch/PKGBUILD
+++ b/linux316-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.16-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=18
+pkgrel=19
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux316-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux316-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux318-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux318-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux318-extramodules/bbswitch/PKGBUILD
+++ b/linux318-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.18-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=18
+pkgrel=19
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux318-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux318-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux319-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux319-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux319-extramodules/bbswitch/PKGBUILD
+++ b/linux319-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-3.19-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=14
+pkgrel=15
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux319-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux319-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux41-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux41-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux41-extramodules/bbswitch/PKGBUILD
+++ b/linux41-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-4.1-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=13
+pkgrel=14
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux41-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux41-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux42-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux42-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux42-extramodules/bbswitch/PKGBUILD
+++ b/linux42-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-4.2-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=10
+pkgrel=11
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux42-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux42-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux44-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux44-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux44-extramodules/bbswitch/PKGBUILD
+++ b/linux44-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-4.4-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=12
+pkgrel=13
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux44-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux44-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux45-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux45-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux45-extramodules/bbswitch/PKGBUILD
+++ b/linux45-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _pkgname=bbswitch
 _extramodules=extramodules-4.5-MANJARO
 _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"
 pkgver=0.8
-pkgrel=7
+pkgrel=8
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=('linux45-headers')
 provides=("$_pkgname=$pkgver")
 groups=('linux45-extramodules')
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   cd ${srcdir}/${_pkgname}-${pkgver}

--- a/linux46-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
+++ b/linux46-extramodules/bbswitch/0001-disable-DSM-if-power-resources-are-in-use.patch
@@ -1,0 +1,59 @@
+From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Fri, 13 May 2016 19:33:07 +0200
+Subject: [PATCH] Disable DSM if power resources are in use
+
+The Optimus _DSM function would prepare a device to be put in D3cold
+state when _PS3 is called. Newer laptops should not use this since
+Windows 8 introduced a new method to put devices in D3cold state[1].
+
+Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
+putting the parent device (PCIe port) is not done in this patch.
+
+ [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
+---
+ bbswitch.c | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/bbswitch.c b/bbswitch.c
+index 341608f..975794a 100644
+--- a/bbswitch.c
++++ b/bbswitch.c
+@@ -197,6 +197,26 @@ static int bbswitch_optimus_dsm(void) {
+     return 0;
+ }
+ 
++// Windows 8/8.1/10 do not use DSM to put the device in D3cold state,
++// instead it disables power resources on the parent PCIe port device.
++static bool has_pr3_support(void) {
++    acpi_handle parent_handle;
++    struct acpi_device *ad = NULL;
++
++    if (ACPI_FAILURE(acpi_get_parent(dis_handle, &parent_handle))) {
++        pr_warn("Failed to obtain the parent device\n");
++        return false;
++    }
++
++    acpi_bus_get_device(parent_handle, &ad);
++    if (!ad) {
++        pr_warn("Failed to obtain an ACPI device for handle\n");
++        return false;
++    }
++
++    return ad->power.flags.power_resources;
++}
++
+ static int bbswitch_acpi_off(void) {
+     if (dsm_type == DSM_TYPE_NVIDIA) {
+         char args[] = {2, 0, 0, 0};
+@@ -436,7 +456,9 @@ static int __init bbswitch_init(void) {
+         return -ENODEV;
+     }
+ 
+-    if (!skip_optimus_dsm &&
++    if (has_pr3_support()) {
++        pr_info("skipping _DSM as _PR3 support is detected\n");
++    } else if (!skip_optimus_dsm &&
+             has_dsm_func(acpi_optimus_dsm_muid, 0x100, 0x1A)) {
+         dsm_type = DSM_TYPE_OPTIMUS;
+         pr_info("detected an Optimus _DSM function\n");

--- a/linux46-extramodules/bbswitch/PKGBUILD
+++ b/linux46-extramodules/bbswitch/PKGBUILD
@@ -7,7 +7,7 @@ _extramodules=extramodules-4.6-MANJARO
 pkgname=$_linuxprefix-bbswitch
 _pkgname=bbswitch
 pkgver=0.8
-pkgrel=0.9
+pkgrel=1
 pkgdesc="kernel module allowing to switch dedicated graphics card on Optimus laptops"
 arch=('i686' 'x86_64')
 url="http://github.com/Bumblebee-Project/bbswitch"
@@ -17,8 +17,15 @@ makedepends=("$_linuxprefix-headers")
 provides=("$_pkgname=$pkgver")
 groups=("$_linuxprefix-extramodules")
 install=bbswitch.install
-source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz")
-sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/Bumblebee-Project/bbswitch/archive/v${pkgver}.tar.gz"
+        '0001-disable-DSM-if-power-resources-are-in-use.patch')
+sha256sums=('76cabd3f734fb4fe6ebfe3ec9814138d0d6f47d47238521ecbd6a986b60d1477'
+            'e3959d8c3526979b6f684c06aaa061b06466a60e4c5009b2fc57cf8a3fdaa600')
+
+prepare() {
+    cd ${srcdir}/${_pkgname}-${pkgver}
+    patch -Np1 -i "${srcdir}/0001-disable-DSM-if-power-resources-are-in-use.patch"
+}
 
 build() {
   _kernver="$(cat /usr/lib/modules/${_extramodules}/version)"


### PR DESCRIPTION
```
From 915413ab92504caa3de6eade077e1efee2b1da65 Mon Sep 17 00:00:00 2001
From: Peter Wu <peter@lekensteyn.nl>
Date: Fri, 13 May 2016 19:33:07 +0200
Subject: [PATCH] Disable DSM if power resources are in use

The Optimus _DSM function would prepare a device to be put in D3cold
state when _PS3 is called. Newer laptops should not use this since
Windows 8 introduced a new method to put devices in D3cold state[1].

Hopefully this fixes an infinite loop on a Clevo P651RA. Actually
putting the parent device (PCIe port) is not done in this patch.

 [1]: https://msdn.microsoft.com/windows/hardware/drivers/bringup/firmware-requirements-for-d3cold
```
@philmmanjaro regards

Source: https://github.com/Bumblebee-Project/bbswitch/commit/915413ab92504caa3de6eade077e1efee2b1da65