### PR TITLE
Add gutenprint to manjaro-printer

### DIFF
--- a/manjaro-meta/PKGBUILD
+++ b/manjaro-meta/PKGBUILD
@@ -55,6 +55,7 @@ package_manjaro-printer() {
 		"cups-pk-helper"
 		"ghostscript"
 		"gsfonts"
+		"gutenprint"
 		"hplip"
 		"python-gobject"
 		"python-pyqt5"


### PR DESCRIPTION
Add **gutenprint** as dependency to **manjaro-printer** meta-package. Arguments in favour of this action:

1. It has drivers for many common used printers
2. It is FOSS (GPL license)
3. It only takes about 30MB of space without loading any services or whatever that could possible slow down the system
4. It was requested on the forum:  https://forum.manjaro.org/t/printing-driver/22806