### PR TITLE
yaourt: update to 1.9

### DIFF
--- a/yaourt/PKGBUILD
+++ b/yaourt/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: Skunnyk <skunnyk@archlinux.fr>
 
 pkgname=yaourt
-pkgver=1.8.1
-pkgrel=3
+pkgver=1.9
+pkgrel=1
 pkgdesc="A pacman wrapper with extended features and AUR support"
 arch=('any')
 url="https://github.com/archlinuxfr/$pkgname"
@@ -15,9 +15,9 @@ optdepends=('aurvote: vote for favorite packages from AUR'
             'customizepkg: automatically modify PKGBUILD during install/upgrade'
             'rsync: retrieve PKGBUILD from official repositories')
 backup=('etc/yaourtrc')
-source=("$url/releases/download/$pkgver/$pkgname-$pkgver.tar.xz" '0001-alpm-manjaro-brand.patch')
-sha256sums=('f5da1144f2d4e9754bc5728116a79a9c78469f6587321c4c766812f06393ca92'
-            'c229900144c61fed7d02f539eacd83cc8789c727aef8ce03de9db75fc26ee6fe')
+source=("$url/releases/download/$pkgver/$pkgname-$pkgver.tar.gz" '0001-alpm-manjaro-brand.patch')
+sha256sums=('9a485cef9d50e80b8abae5dbb147e09bdeb8818d29316b65e892fb560c48517d'
+            '3d53b2b83b013cee95b135e1aea120eca82f1ec42a028e48d7783967d97edf2f')
 
 prepare() {
     cd "$pkgname-$pkgver"


### PR DESCRIPTION
Yaourt has been updated to version 1.9 in AUR on 2017-07-20 04:22

I was wondering maybe I can update its PKGBUILD in extra repo? Hope you don't mind?

It built just fine on my end with this PKGBUILD (even with the manjaro-branding patch) : 

```
~ >>> yaourt --version                                                                                                                                                
yaourt 1.9
homepage: http://archlinux.fr/yaourt-en
```

```
~ >>> yaourt --stats                                                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
|                                                                     Manjaro Linux  (yaourt 1.9)                                                                     |
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total installed packages:  1346
Explicitly installed packages:  477
Packages installed as dependencies to run other packages:  869
Packages out of date:  0
Where 5 packages seem to no longer be in use by any package:
    doxygen libfm-gtk2 lxmenu-data swig xfce4-dev-tools
Hold packages: (2) pacman glibc
Ignored packages: (0) 
Ignored groups: (0) 

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
Number of configured repositories:  9
Packages by repositories (ordered by pacmans priority):
    system(217), world(65), galaxy(3), core(10), extra(678), community(200), multilib(157), manjaro-strit(1), nulogic(0),  others*(15)

    *others are packages from local build or AUR Unsupported

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
                                                                                                                                                                       
Theoretical space used by packages: 5935M
Real space used by packages: 5866M
Space used by pkg downloaded in cache (cachedir):  5.7G
Space used by src downloaded in cache:  0M
```