### PR TITLE
bump package-query to 1.9

### DIFF
--- a/package-query/PKGBUILD
+++ b/package-query/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Skunnyk <skunnyk@archlinux.fr>
 
 pkgname=package-query
-pkgver=1.8
+pkgver=1.9
 pkgrel=1
 pkgdesc="Query ALPM and AUR"
 arch=('i686' 'x86_64' 'mips64el' 'armv6h' 'armv7h' 'arm')
@@ -10,7 +10,7 @@ url="https://github.com/archlinuxfr/$pkgname/"
 license=('GPL')
 depends=('pacman>=5.0' 'yajl>=2.0')
 source=("http://mir.archlinux.fr/releases/$pkgname/$pkgname-$pkgver.tar.gz")
-md5sums=('dd3465672fff2a65db6768a5f20efc9a')
+sha256sums=('88bc3970fd05a16778c52d5aafc19e930aadd0d6b4c6b142f8fff47ec22ef785')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
This pull request will update package-query into 1.9 to reflect the changes from the AUR ...

https://aur.archlinux.org/packages/package-query

Thanks!