### PR TITLE
Remove libvpx as dependency

### DIFF
--- a/firefox/PKGBUILD
+++ b/firefox/PKGBUILD
@@ -12,7 +12,7 @@ arch=(i686 x86_64)
 license=(MPL GPL LGPL)
 url="https://www.mozilla.org/firefox/"
 depends=(gtk3 gtk2 mozilla-common libxt startup-notification mime-types dbus-glib alsa-lib ffmpeg
-         nss hunspell sqlite ttf-font libpulse icu libvpx)
+         nss hunspell sqlite ttf-font libpulse icu)
 optdepends=('networkmanager: Location detection via available WiFi networks'
             'libnotify: Notification integration'
             'pulseaudio: Audio support'


### PR DESCRIPTION
Remove the libvpx dependency as it is not needed anymore. You can look at the arch pkgbuild as well : 
https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/firefox&id=44e8e010c7c02cbae56a2bbc1254ba43c22a3b85