### PR TITLE
Add thunar-archive-plugin-gtk3 which works with thunar-gtk3

### DIFF
--- a/xfce4-gtk3/thunar-archive-plugin-gtk3/0001-Fix-file-roller-3.12.1-detection-bug-10826.patch
+++ b/xfce4-gtk3/thunar-archive-plugin-gtk3/0001-Fix-file-roller-3.12.1-detection-bug-10826.patch
@@ -1,0 +1,37 @@
+From cc1b9c86d1b563318a2b9489b062f9519ae08b20 Mon Sep 17 00:00:00 2001
+From: Evangelos Foutras <evangelos@foutrelis.com>
+Date: Wed, 23 Apr 2014 20:13:19 +0300
+Subject: [PATCH] Fix file-roller>=3.12.1 detection (bug #10826)
+
+File Roller 3.12.1 changed the name of its .desktop file from
+file-roller.desktop to org.gnome.FileRoller.desktop.
+
+We install a new symlink to support the new .desktop file name.
+---
+ scripts/Makefile.am | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/Makefile.am b/scripts/Makefile.am
+index 4da529c..3804605 100644
+--- a/scripts/Makefile.am
++++ b/scripts/Makefile.am
+@@ -5,12 +5,15 @@ wrapper_SCRIPTS =							\
+ 	ark.tap								\
+ 	file-roller.tap
+ 
+-# Install symlink to 'gnome-file-roller.tap'
++# Install symlink to 'gnome-file-roller.tap' and 'org.gnome.FileRoller.tap'
+ install-exec-hook:
+ 	$(mkinstalldirs) $(DESTDIR)$(wrapperdir)
+ 	-( cd $(DESTDIR)$(wrapperdir) ; \
+ 		test -f gnome-file-roller.tap \
+ 		|| ln -sf file-roller.tap gnome-file-roller.tap )
++	-( cd $(DESTDIR)$(wrapperdir) ; \
++		test -f org.gnome.FileRoller.tap \
++		|| ln -sf file-roller.tap org.gnome.FileRoller.tap )
+ 
+ EXTRA_DIST =								\
+ 	$(wrapper_SCRIPTS)						\
+-- 
+1.9.2
+

--- a/xfce4-gtk3/thunar-archive-plugin-gtk3/PKGBUILD
+++ b/xfce4-gtk3/thunar-archive-plugin-gtk3/PKGBUILD
@@ -1,0 +1,66 @@
+# $Id$
+# Maintainer: Evangelos Foutras <evangelos@foutrelis.com>
+# Contributor: Tobias Kieslich <tobias (at) archlinux.org>
+
+_pkgname=thunar-archive-plugin
+pkgname=$_pkgname-gtk3
+pkgver=0.3.1
+pkgrel=1
+_commit=cf91e938eacf9291f9f2616e48cbd70a501724be
+pkgdesc="Create and extract archives in Thunar"
+arch=('i686' 'x86_64')
+url="http://goodies.xfce.org/projects/thunar-plugins/thunar-archive-plugin"
+license=('GPL2')
+groups=('xfce4-gtk3-goodies')
+depends=('thunar-gtk3' 'hicolor-icon-theme')
+makedepends=('intltool' 'xfce4-dev-tools')
+conflicts=(${_pkgname})
+replaces=(${_pkgname})
+optdepends=('file-roller'
+            'kdeutils-ark'
+            'xarchiver')
+source=(https://git.xfce.org/thunar-plugins/${_pkgname}/snapshot/${_pkgname}-${_commit}.tar.bz2
+        0001-Fix-file-roller-3.12.1-detection-bug-10826.patch
+	patch1.patch::https://github.com/andreldm/thunar-archive-plugin/commit/3ab18ce256a8b66d0d294b3222e3b76cc5d884e5.patch
+	patch2.patch::https://github.com/andreldm/thunar-archive-plugin/commit/3b7c8d10e4242d4938657fac9bd0204aaa0c2217.patch
+	patch3.patch::https://github.com/andreldm/thunar-archive-plugin/commit/5083c2bc5cc78e8ebe69866a262a21353cb1830d.patch
+	patch4.patch::https://github.com/andreldm/thunar-archive-plugin/commit/9d5de649793810f76eae8a18fd3227acb9c26a07.patch
+	patch5.patch::https://github.com/andreldm/thunar-archive-plugin/commit/faedc3bc5ca6ba10e378c0ff6d5e0666322d5294.patch
+	)
+sha256sums=('8515f3e9ad9423f0b81c28e78e6319e67d0ad193d6b255c36209a41679c0e63f'
+            '4373c3011f5abd1d4119d283e832aeb858c810f14b3a59b6250cf10893aa0757'
+            '795c693ff65bcd95b70fcbab3849569d7b99723f918eb892d5916b90b145ee21'
+            'eed45c7b9cf831b4ab83366fe5855bc86f69ed55baa4ae1ecfc09f7ea69ce3ff'
+            '48457986dc8982b9296cb455a6862dab5052968a59e1fe6d834d3a0541032aa8'
+            '837e86e47ef8065e32e17a6dd8fb7e0a638c7c033e5d40f88e1b05373686c821'
+            'f35067f37649ee0161bcc291a9550e658efe4b4394d0f5983d5ed9d8e92750ad')
+
+prepare() {
+  cd "$srcdir/${_pkgname}-${_commit}"
+
+  # https://bugzilla.xfce.org/show_bug.cgi?id=10826
+  patch -Np1 -i ../0001-Fix-file-roller-3.12.1-detection-bug-10826.patch
+  patch -Np1 -i ../patch1.patch
+  patch -Np1 -i ../patch2.patch
+  patch -Np1 -i ../patch3.patch
+  patch -Np1 -i ../patch4.patch
+  patch -Np1 -i ../patch5.patch
+  NOCONFIGURE=1 xdt-autogen
+}
+
+build() {
+  cd "$srcdir/${_pkgname}-${_commit}"
+
+  ./configure \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --libexecdir=/usr/lib/xfce4 \
+    --localstatedir=/var \
+    --disable-static
+  make
+}
+
+package() {
+  cd "$srcdir/${_pkgname}-${_commit}"
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
@oberon2007 It seems like some gtk3 work for the thunar-archive-plugin happened at this repository: https://github.com/andreldm/thunar-archive-plugin/commits/master arround May, but it hasn't been merged upstream yet.

So, I chose to add those commits as patches over the latest commit of the official xfce git repository (https://git.xfce.org/thunar-plugins/thunar-archive-plugin/), except for the commit which fixes the file-roller recognition, for whitch I kept the original patch from the arch package (they do exactly the same fix). Of course you can just build the thunar-archive-plugin from the github repository which has the gtk3 work, but it's kinda outdated in comparison with the official repository's master branch and I don't know if it's missing anything important (most likely not, since the official repository has only translation updates as far as I can see).

P.S. I see both xfce4-gtk3-goodies and xfce4-goodies-gtk3 groups at my system, but if I understood correctly you are going to keep only the 1st one, so this is the one I chose.