### PR TITLE
[documentation] Fix font error when compiling

### DIFF
--- a/manjaro-documentation-fr/PKGBUILD
+++ b/manjaro-documentation-fr/PKGBUILD
@@ -16,6 +16,7 @@ sha256sums=('3b643b45aeb33ca60694759d5c2d124398ceaf48467eed43d567dd8d1abf26b8'
             'cfdc3cc5fb759b835f2cb9bca830ea0ea48b4ab98b58867c0420930e890d74c6')
 
 prepare() {
+  updmap-user --cnffile=/etc/texmf/web2c/updmap.cfg
   cd ${srcdir}/manjaro-user-guide-$_gitcommit
   lyx --export pdflatex manjaro-user-guide.lyx
   pdflatex manjaro-user-guide

--- a/manjaro-documentation/PKGBUILD
+++ b/manjaro-documentation/PKGBUILD
@@ -16,6 +16,7 @@ sha256sums=('9fdb3ede16f73c3509f673833591f43e908ab5c20815c9da1baaed1d582db033'
             'cccdd31319b8157162a42d80e41b5606dce9aeb30587eca0d8b0e056b3b4717a')
 
 prepare() {
+  updmap-user --cnffile=/etc/texmf/web2c/updmap.cfg
   cd ${srcdir}/manjaro-user-guide-$_gitcommit
   lyx --export pdflatex manjaro-user-guide.lyx
   pdflatex manjaro-user-guide


### PR DESCRIPTION
Fix to prevent a compilation error when using the Palatino font.  The map file is updated while explicitly specifying a config file before beginning to compile the LaTeX code.