### PR TITLE
[nvidia-utils] Install Vulkan library libnvidia-glvkspirv.so

### DIFF
--- a/nvidia-utils/PKGBUILD
+++ b/nvidia-utils/PKGBUILD
@@ -122,7 +122,8 @@ package_nvidia-utils() {
     install -D -m755 "libnvidia-cfg.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-cfg.so.${pkgver}"
     install -D -m755 "libnvidia-ml.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-ml.so.${pkgver}"
 
-    # Vulkan ICD
+    # Vulkan
+    install -D -m644 "libnvidia-glvkspirv.so.${pkgver}" "${pkgdir}/usr/lib/libnvidia-glvkspirv.so.${pkgver}"
     install -D -m644 "nvidia_icd.json.template" "${pkgdir}/usr/share/vulkan/icd.d/nvidia_icd.json"
 
     # VDPAU


### PR DESCRIPTION
Fixes missing Vulkan library:

https://forum.manjaro.org/t/broken-nvidia-vulkan-in-396-18-and-fix/45208
https://devtalk.nvidia.com/default/topic/1032079/dota2-seems-to-be-broken-with-396-18-and-vulkan/