### PR TITLE
[manjaro-settings-samba] Remove group = sambashare

### DIFF
--- a/manjaro-settings-samba/smb.conf
+++ b/manjaro-settings-samba/smb.conf
@@ -20,7 +20,6 @@
    usershare path = /var/lib/samba/usershare
    usershare max shares = 100
    usershare owner only = yes
-   group = sambashare
    force create mode = 0070
    force directory mode = 0070
 


### PR DESCRIPTION
Since it prevents users from creating usershares graphically on Samba 4.8.1. Users get error 255: net usershare add: cannot convert name "Everyone" to a SID.